### PR TITLE
Adds a policy compiler

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -16,3 +16,22 @@
 /// Core Module for simplicity
 pub mod term;
 pub mod types;
+
+// handy function for converting bit vector to vec[u8]
+// # PANIC:
+// panics when bitvec length is not a multiple of 8.
+pub(crate) fn bitvec_to_bytevec(bitvec: Vec<bool>) -> Vec<u8> {
+    let mut ret = vec![];
+    assert!(bitvec.len() % 8 == 0, "Bitvec len must be multiple of 8");
+    let mut start = 0;
+    while start < bitvec.len() {
+        //read a byte
+        let mut byte: u8 = 0;
+        for i in 0..8 {
+            byte += (bitvec[start + i] as u8) * (1u8 << (7 - i));
+        }
+        ret.push(byte);
+        start += 8;
+    }
+    ret
+}

--- a/src/core/term.rs
+++ b/src/core/term.rs
@@ -311,6 +311,30 @@ impl Value {
         Value::Prod(Box::new(Value::u32(w0)), Box::new(Value::u32(w1)))
     }
 
+    /// Convert the value to a byte array.
+    pub fn into_bits(self) -> Vec<bool> {
+        let mut ret = vec![];
+        fn into_bit_helper(v: Value, ret: &mut Vec<bool>) {
+            match v {
+                Value::Unit => {}
+                Value::SumL(l) => {
+                    ret.push(false);
+                    into_bit_helper(*l, ret);
+                }
+                Value::SumR(r) => {
+                    ret.push(true);
+                    into_bit_helper(*r, ret);
+                }
+                Value::Prod(l, r) => {
+                    into_bit_helper(*l, ret);
+                    into_bit_helper(*r, ret);
+                }
+            }
+        }
+        into_bit_helper(self, &mut ret);
+        ret
+    }
+
     /// Convenience constructor for a left sum of a value
     pub fn sum_l(a: Value) -> Value {
         Value::SumL(Box::new(a))

--- a/src/extension/bitcoin.rs
+++ b/src/extension/bitcoin.rs
@@ -42,8 +42,20 @@ impl TxEnv {
     }
 }
 
+impl Default for TxEnv {
+    fn default() -> TxEnv {
+        // FIXME: Review and check if the defaults make sense
+        TxEnv::from_tx(bitcoin::Transaction {
+            version: 2,
+            lock_time: 0,
+            input: vec![],
+            output: vec![],
+        })
+    }
+}
+
 /// Set of new Simplicity nodes enabled by the Bitcoin extension
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 pub enum BtcNode {
     Version,
     LockTime,

--- a/src/extension/elements.rs
+++ b/src/extension/elements.rs
@@ -40,6 +40,17 @@ impl TxEnv {
     }
 }
 
+impl Default for TxEnv {
+    fn default() -> TxEnv {
+        TxEnv::from_tx(elements::Transaction {
+            version: 2,
+            lock_time: 0,
+            input: vec![],
+            output: vec![],
+        })
+    }
+}
+
 /// Set of new Simplicity nodes enabled by the Bitcoin extension
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub enum ElementsNode {

--- a/src/extension/jets.rs
+++ b/src/extension/jets.rs
@@ -42,6 +42,9 @@ pub enum JetsNode {
     SchnorrAssert,
     // Temparory jets for compiler
     EqV256,
+    Sha256,
+    LessThanV32, // less than verify for u32
+    EqV32,
 }
 
 impl fmt::Display for JetsNode {
@@ -56,6 +59,9 @@ impl fmt::Display for JetsNode {
             JetsNode::Sha256HashBlock => "sha256hashblock",
             JetsNode::SchnorrAssert => "schnorrassert",
             JetsNode::EqV256 => "eqv256",
+            JetsNode::Sha256 => "sha256",
+            JetsNode::LessThanV32 => "le32",
+            JetsNode::EqV32 => "eqv32",
         })
     }
 }
@@ -74,6 +80,9 @@ impl extension::Jet for JetsNode {
             JetsNode::Sha256HashBlock => TypeName(b"*h*hh"),
             JetsNode::SchnorrAssert => TypeName(b"*h*hh"),
             JetsNode::EqV256 => TypeName(b"*hh"),
+            JetsNode::Sha256 => TypeName(b"*hh"),
+            JetsNode::LessThanV32 => TypeName(b"l"),
+            JetsNode::EqV32 => TypeName(b"l"),
         }
     }
 
@@ -89,6 +98,9 @@ impl extension::Jet for JetsNode {
             JetsNode::Sha256HashBlock => TypeName(b"h"),
             JetsNode::SchnorrAssert => TypeName(b"1"),
             JetsNode::EqV256 => TypeName(b"1"),
+            JetsNode::Sha256 => TypeName(b"h"),
+            JetsNode::LessThanV32 => TypeName(b"1"),
+            JetsNode::EqV32 => TypeName(b"1"),
         }
     }
 
@@ -134,12 +146,27 @@ impl extension::Jet for JetsNode {
             JetsNode::SchnorrAssert => cmr.update_1(Cmr::from([
                 0xee, 0xae, 0x47, 0xe2, 0xf7, 0x87, 0x6c, 0x3b, 0x9c, 0xbc, 0xd4, 0x04, 0xa3, 0x38,
                 0xb0, 0x89, 0xfd, 0xea, 0xdf, 0x1b, 0x9b, 0xb3, 0x82, 0xec, 0x6e, 0x69, 0x71, 0x9d,
-                0x31, 0xba, 0xec, 0x9b, //only last `a` changed to `b` from sha2 cmr
+                0x31, 0xba, 0xec, 0x9b, //only last `a` changed to `b` from sha2 block cmr
             ])),
             JetsNode::EqV256 => cmr.update_1(Cmr::from([
                 0xee, 0xae, 0x47, 0xe2, 0xf7, 0x87, 0x6c, 0x3b, 0x9c, 0xbc, 0xd4, 0x04, 0xa3, 0x38,
                 0xb0, 0x89, 0xfd, 0xea, 0xdf, 0x1b, 0x9b, 0xb3, 0x82, 0xec, 0x6e, 0x69, 0x71, 0x9d,
-                0x31, 0xba, 0xec, 0x9c, //only last `a` changed to `c` from sha2 cmr
+                0x31, 0xba, 0xec, 0x9c, //only last `a` changed to `c` from sha2 block cmr
+            ])),
+            JetsNode::Sha256 => cmr.update_1(Cmr::from([
+                0xee, 0xae, 0x47, 0xe2, 0xf7, 0x87, 0x6c, 0x3b, 0x9c, 0xbc, 0xd4, 0x04, 0xa3, 0x38,
+                0xb0, 0x89, 0xfd, 0xea, 0xdf, 0x1b, 0x9b, 0xb3, 0x82, 0xec, 0x6e, 0x69, 0x71, 0x9d,
+                0x31, 0xba, 0xec, 0x9d, //only last `a` changed to `d` from sha2 block cmr
+            ])),
+            JetsNode::LessThanV32 => cmr.update_1(Cmr::from([
+                0xee, 0xae, 0x47, 0xe2, 0xf7, 0x87, 0x6c, 0x3b, 0x9c, 0xbc, 0xd4, 0x04, 0xa3, 0x38,
+                0xb0, 0x89, 0xfd, 0xea, 0xdf, 0x1b, 0x9b, 0xb3, 0x82, 0xec, 0x6e, 0x69, 0x71, 0x9d,
+                0x31, 0xba, 0xec, 0x9e, //only last `a` changed to `e` from sha2 block cmr
+            ])),
+            JetsNode::EqV32 => cmr.update_1(Cmr::from([
+                0xee, 0xae, 0x47, 0xe2, 0xf7, 0x87, 0x6c, 0x3b, 0x9c, 0xbc, 0xd4, 0x04, 0xa3, 0x38,
+                0xb0, 0x89, 0xfd, 0xea, 0xdf, 0x1b, 0x9b, 0xb3, 0x82, 0xec, 0x6e, 0x69, 0x71, 0x9d,
+                0x31, 0xba, 0xec, 0x9f, //only last `a` changed to `f` from sha2 block cmr
             ])),
         }
     }
@@ -156,6 +183,9 @@ impl extension::Jet for JetsNode {
             JetsNode::Sha256HashBlock => w.write_u8(14, 4),
             JetsNode::SchnorrAssert => w.write_u8(15 * 16 + 0, 8),
             JetsNode::EqV256 => w.write_u8(15 * 16 + 1, 8),
+            JetsNode::Sha256 => w.write_u8(15 * 16 + 2, 8),
+            JetsNode::LessThanV32 => w.write_u8(15 * 16 + 3, 8),
+            JetsNode::EqV32 => w.write_u8(15 * 16 + 3, 8),
         }
     }
 
@@ -197,6 +227,9 @@ impl extension::Jet for JetsNode {
                     match code {
                         0 => Ok(JetsNode::SchnorrAssert),
                         1 => Ok(JetsNode::EqV256),
+                        2 => Ok(JetsNode::Sha256),
+                        3 => Ok(JetsNode::LessThanV32),
+                        4 => Ok(JetsNode::EqV32),
                         _ => unreachable!(),
                     }
                 }
@@ -272,6 +305,26 @@ impl extension::Jet for JetsNode {
 
                 // FIXME:
                 // Get Error here instead of assert
+                assert!(a == b);
+            }
+            JetsNode::Sha256 => {
+                let data = mac.read_32bytes();
+                let h = sha256::Hash::hash(&data);
+
+                mac.write_bytes(&h);
+            }
+            JetsNode::LessThanV32 => {
+                let a = mac.read_u32();
+                let b = mac.read_u32();
+
+                // FIXME: error
+                assert!(a < b);
+            }
+            JetsNode::EqV32 => {
+                let a = mac.read_u32();
+                let b = mac.read_u32();
+
+                // FIXME: error
                 assert!(a == b);
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ use std::fmt;
 
 pub use crate::bit_machine::exec;
 pub use crate::core::term::Term;
+pub use crate::core::term::UnTypedProg;
 pub use crate::core::term::Value;
 pub use crate::program::Program;
 
@@ -100,14 +101,23 @@ impl From<miniscript::Error> for Error {
 }
 
 /// Trait describing public key types which can be converted to bitcoin pubkeys
-pub trait To32BytePubKey: MiniscriptKey {
+pub trait PubkeyKey32: MiniscriptKey {
     /// Converts an object to a public key
     fn to_32_byte_pubkey(&self) -> [u8; 32];
+
+    fn from_32_byte_pubkey(bytes: &[u8]) -> Self;
 }
 
-impl To32BytePubKey for DummyKey {
+impl PubkeyKey32 for DummyKey {
     // Dummy value which returns a 32 byte public.
     fn to_32_byte_pubkey(&self) -> [u8; 32] {
         [0xab; 32]
+    }
+
+    fn from_32_byte_pubkey(bytes: &[u8]) -> Self {
+        if *bytes != [0xab; 32] {
+            panic!("Unable to parse DummyKey from bytes")
+        }
+        DummyKey
     }
 }

--- a/src/policy/ast.rs
+++ b/src/policy/ast.rs
@@ -33,7 +33,7 @@ use crate::extension::bitcoin::BtcNode;
 
 use crate::core::term::UnTypedProg;
 use crate::Error;
-use crate::To32BytePubKey;
+use crate::PubkeyKey32;
 
 use super::compiler;
 
@@ -62,7 +62,7 @@ pub enum Policy<Pk: MiniscriptKey> {
     /// A set of sub-policies, satisfactions must be provided for `k` of them
     Threshold(usize, Vec<Policy<Pk>>),
 }
-impl<Pk: MiniscriptKey + To32BytePubKey> Policy<Pk> {
+impl<Pk: MiniscriptKey + PubkeyKey32> Policy<Pk> {
     /// Compile a policy into a simplicity frgament
     pub fn compile(&self) -> Result<UnTypedProg<(), BtcNode>, Error> {
         let dag = compiler::compile(&self)?;

--- a/src/policy/ast.rs
+++ b/src/policy/ast.rs
@@ -20,7 +20,6 @@
 //! These policies can be compiled to Simplicity and also be lifted back up from
 //! Simplicity expressions to policy.
 
-use std::hash::Hash;
 use std::{fmt, str};
 
 use bitcoin_hashes::hex::FromHex;
@@ -30,7 +29,7 @@ use miniscript::expression;
 use miniscript::Error as msError;
 use miniscript::MiniscriptKey;
 
-use crate::extension::Jet;
+use crate::extension::bitcoin::BtcNode;
 
 use crate::core::term::UnTypedProg;
 use crate::Error;
@@ -65,7 +64,7 @@ pub enum Policy<Pk: MiniscriptKey> {
 }
 impl<Pk: MiniscriptKey + To32BytePubKey> Policy<Pk> {
     /// Compile a policy into a simplicity frgament
-    pub fn compile<Ext: Jet + Hash + Clone>(&self) -> Result<UnTypedProg<(), Ext>, Error> {
+    pub fn compile(&self) -> Result<UnTypedProg<(), BtcNode>, Error> {
         let dag = compiler::compile(&self)?;
         Ok(dag.into_untyped_prog())
     }
@@ -349,7 +348,7 @@ mod tests {
     use super::*;
     use crate::bititer::BitIter;
     use crate::exec;
-    use crate::extension::dummy::{DummyNode, TxEnv};
+    use crate::extension::bitcoin::{BtcNode, TxEnv};
     use crate::program::Program;
     use crate::DummyKey;
     use crate::Value;
@@ -358,14 +357,16 @@ mod tests {
     fn compile_and_exec(pol: &str, witness: Vec<u8>) {
         // A single pk compilation
         let pol = Policy::<DummyKey>::from_str(pol).unwrap();
-        let prog: UnTypedProg<_, DummyNode> = pol.compile().unwrap();
+        let prog: UnTypedProg<_, BtcNode> = pol.compile().unwrap();
 
         let prog =
             Program::from_untyped_nodes(prog, &mut BitIter::from(witness.into_iter())).unwrap();
         // prog.graph_print();
 
+        let txenv = TxEnv::default();
+
         let mut mac = exec::BitMachine::for_program(&prog);
-        let output = mac.exec(&prog, &TxEnv);
+        let output = mac.exec(&prog, &txenv);
 
         assert!(output == Value::Unit);
     }

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -17,17 +17,20 @@
 //! between policy fragment and a simplicity program.
 
 use super::ast::Policy;
+use crate::bitcoin_hashes::Hash;
 use crate::bititer::BitIter;
 use crate::core::term::DagTerm;
-use crate::extension;
+use crate::core::types::pow2_types;
+use crate::extension::bitcoin::BtcNode;
+use crate::extension::jets::JetsNode::{
+    Adder32, EqV256, EqV32, LessThanV32, SchnorrAssert, Sha256,
+};
 use crate::miniscript::MiniscriptKey;
 use crate::Error;
 use crate::To32BytePubKey;
 use crate::Value;
 
 use std::rc::Rc;
-
-use crate::core::types::pow2_types;
 
 /// Scribe progra: for any value of a Simplicity type b :B, the constant function
 /// from A -> B can be realized by a Simplicity expression called scribe.  
@@ -52,51 +55,128 @@ pub fn scribe<Ext>(b: Value) -> DagTerm<(), Ext> {
     }
 }
 
-pub fn compile<Pk: MiniscriptKey + To32BytePubKey, Ext: extension::Jet>(
+/// constant function that returns false
+pub fn zero<Ext>() -> DagTerm<(), Ext> {
+    scribe(Value::sum_l(Value::Unit))
+}
+
+/// constant function that returns true
+pub fn one<Ext>() -> DagTerm<(), Ext> {
+    scribe(Value::sum_r(Value::Unit))
+}
+
+/// Cond program: The combinator to branch based on the value of a
+/// bit using case and drop. The first argument is the
+/// then clause and the second argument is the else clause
+/// [[cond st]] <0, a> = [[s]](a); [[cond st]] <1, a> = [[t]](a)
+pub fn cond<Ext>(s: Rc<DagTerm<(), Ext>>, t: Rc<DagTerm<(), Ext>>) -> DagTerm<(), Ext> {
+    DagTerm::Case(Rc::new(DagTerm::Drop(s)), Rc::new(DagTerm::Drop(t)))
+}
+
+/// Convert a single bit into u2 by pre-padding zeros
+fn u1_to_u2<Ext>(s: Rc<DagTerm<(), Ext>>) -> DagTerm<(), Ext> {
+    DagTerm::Pair(Rc::new(scribe(Value::u1(0))), s)
+}
+
+/// Convert a single bit into u4 by pre-padding zeros
+fn u1_to_u4<Ext>(s: Rc<DagTerm<(), Ext>>) -> DagTerm<(), Ext> {
+    DagTerm::Pair(Rc::new(scribe(Value::u2(0))), Rc::new(u1_to_u2(s)))
+}
+
+/// Convert a single bit into u8 by pre-padding zeros
+fn u1_to_u8<Ext>(s: Rc<DagTerm<(), Ext>>) -> DagTerm<(), Ext> {
+    DagTerm::Pair(Rc::new(scribe(Value::u4(0))), Rc::new(u1_to_u4(s)))
+}
+
+/// Convert a single bit into u16 by pre-padding zeros
+fn u1_to_u16<Ext>(s: Rc<DagTerm<(), Ext>>) -> DagTerm<(), Ext> {
+    DagTerm::Pair(Rc::new(scribe(Value::u8(0))), Rc::new(u1_to_u8(s)))
+}
+
+/// Convert a single bit into u32 by pre-padding zeros
+fn u1_to_u32<Ext>(s: Rc<DagTerm<(), Ext>>) -> DagTerm<(), Ext> {
+    DagTerm::Pair(Rc::new(scribe(Value::u16(0))), Rc::new(u1_to_u16(s)))
+}
+
+/// Compile the desired policy into a bitcoin simplicity program
+pub fn compile<Pk: MiniscriptKey + To32BytePubKey>(
     pol: &Policy<Pk>,
-) -> Result<DagTerm<(), Ext>, Error> {
-    let pk_ty = pow2_types()[9].clone();
+) -> Result<DagTerm<(), BtcNode>, Error> {
+    let two_pow_256 = pow2_types()[9].clone();
     let frag = match pol {
-        Policy::Unsatisfiable => unimplemented!(),
-        Policy::Trivial => unimplemented!(),
+        Policy::Unsatisfiable => unimplemented!(), //lookup  fail
+        Policy::Trivial => DagTerm::Unit,
         Policy::Key(ref pk) => {
             let pk_value = Value::from_bits_and_type(
                 &mut BitIter::from(pk.to_32_byte_pubkey().to_vec().into_iter()),
-                &pk_ty,
+                &two_pow_256,
             )?;
             let scribe_pk = scribe(pk_value);
             let pk_sig_pair = DagTerm::Pair(Rc::new(scribe_pk), Rc::new(DagTerm::Witness(())));
+            DagTerm::Comp(Rc::new(pk_sig_pair), Rc::new(DagTerm::Jet(SchnorrAssert)))
+        }
+        Policy::Sha256(ref h) => {
+            let hash_value = Value::from_bits_and_type(
+                &mut BitIter::from(h.into_inner().to_vec().into_iter()),
+                &two_pow_256,
+            )?;
+            // scribe target hash
+            let scribe_hash = scribe(hash_value);
+            // compute the preimage hash. An implicit contraint on the len=32 is enfored
+            // by the typesystem.
+            let computed_hash =
+                DagTerm::Comp(Rc::new(DagTerm::Witness(())), Rc::new(DagTerm::Jet(Sha256)));
+            // Check eq256 here
+            let pair = DagTerm::Pair(Rc::new(scribe_hash), Rc::new(computed_hash));
+            DagTerm::Comp(Rc::new(pair), Rc::new(DagTerm::Jet(EqV256)))
+        }
+        Policy::After(n) => {
+            let cltv = DagTerm::Ext(BtcNode::LockTime);
+            let n_value = Value::u32(*n);
+            let scribe_n = scribe(n_value);
+            let pair = DagTerm::Pair(Rc::new(scribe_n), Rc::new(cltv));
+            DagTerm::Comp(Rc::new(pair), Rc::new(DagTerm::Jet(LessThanV32)))
+        }
+        Policy::Older(n) => {
+            let csv = DagTerm::Ext(BtcNode::CurrentSequence);
+            let n_value = Value::u32(*n);
+            let scribe_n = scribe(n_value);
+            let pair = DagTerm::Pair(Rc::new(scribe_n), Rc::new(csv));
+            DagTerm::Comp(Rc::new(pair), Rc::new(DagTerm::Jet(LessThanV32)))
+        }
+        Policy::Threshold(k, ref subs) => {
+            assert!(subs.len() >= 2, "Threshold must have numbre of subs >=2");
+            let child = compile(&subs[0])?;
+            // selector denotes a bit that specifies whether the first child should be executed.
+            let selector = Rc::new(DagTerm::Witness(()));
+            // The case condition that for the current child
+            let case_term = cond(Rc::new(child), Rc::new(DagTerm::Unit));
+            let mut acc = DagTerm::Comp(Rc::clone(&selector), Rc::new(case_term));
+            let mut sum = u1_to_u32(selector);
+            for sub in &subs[1..] {
+                let child = compile(sub)?;
+                let selector = Rc::new(DagTerm::Witness(()));
+                let case_term = cond(Rc::new(child), Rc::new(DagTerm::Unit));
+
+                let curr_term = DagTerm::Comp(Rc::clone(&selector), Rc::new(case_term));
+                let selector_u32 = u1_to_u32(selector);
+
+                acc = DagTerm::Comp(Rc::new(acc), Rc::new(curr_term));
+                let full_sum = DagTerm::Comp(
+                    Rc::new(DagTerm::Pair(Rc::new(sum), Rc::new(selector_u32))),
+                    Rc::new(DagTerm::Jet(Adder32)),
+                );
+                // Discard the overflow bit.
+                // NOTE: This *assumes* that the threshold would be have 2**32 branches.
+                // FIXME: enforce this in policy specification.
+                sum = DagTerm::Drop(Rc::new(full_sum));
+            }
+            let scribe_k = scribe(Value::u32(*k as u32));
             DagTerm::Comp(
-                Rc::new(pk_sig_pair),
-                Rc::new(DagTerm::Jet(extension::jets::JetsNode::SchnorrAssert)),
+                Rc::new(DagTerm::Pair(Rc::new(scribe_k), Rc::new(sum))),
+                Rc::new(DagTerm::Jet(EqV32)),
             )
         }
-        Policy::Sha256(ref _h) => {
-            unimplemented!()
-            // use bitcoin_hashes::Hash;
-            // use bitcoin_hashes::HashEngine;
-            // let x = sha256::HashEngine::default();
-            // let midstate = x.midstate().0;
-            // let midstate_value =
-            //     Value::from_bits_and_type(&mut BitIter::from(h.to_vec().into_iter()), &pk_ty)?;
-            // let mut nodes = scribe(midstate_value);
-            // nodes.push(Node::Witness(()));
-            // nodes.push(Node::Pair(2, 1));
-            // nodes.push(Node::Jet(extension::jets::Node::Sha256HashBlock));
-            // nodes.push(Node::Comp(2, 1));
-            // // Add the equality test here
-            // let hash_value = Value::from_bits_and_type(
-            //     &mut BitIter::from(h.into_inner().to_vec().into_iter()),
-            //     &pk_ty,
-            // )?;
-            // let nodes2 = scribe(hash_value);
-            // let li = nodes2.len() + 1;
-            // // Check eq256 here
-            // nodes
-        }
-        Policy::After(_n) => unimplemented!(),
-        Policy::Older(_n) => unimplemented!(),
-        Policy::Threshold(_k, ref _subs) => unimplemented!(),
         Policy::And(ref subs) => {
             assert!(subs.len() == 2);
             let l = compile(&subs[0])?;
@@ -107,7 +187,7 @@ pub fn compile<Pk: MiniscriptKey + To32BytePubKey, Ext: extension::Jet>(
             assert!(subs.len() == 2);
             let l = compile(&subs[0])?;
             let r = compile(&subs[1])?;
-            let case_term = DagTerm::Case(Rc::new(l), Rc::new(r));
+            let case_term = cond(Rc::new(l), Rc::new(r));
             DagTerm::Comp(Rc::new(DagTerm::Witness(())), Rc::new(case_term))
         }
     };

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -27,7 +27,7 @@ use crate::extension::jets::JetsNode::{
 };
 use crate::miniscript::MiniscriptKey;
 use crate::Error;
-use crate::To32BytePubKey;
+use crate::PubkeyKey32;
 use crate::Value;
 
 use std::rc::Rc;
@@ -99,7 +99,7 @@ fn u1_to_u32<Ext>(s: Rc<DagTerm<(), Ext>>) -> DagTerm<(), Ext> {
 }
 
 /// Compile the desired policy into a bitcoin simplicity program
-pub fn compile<Pk: MiniscriptKey + To32BytePubKey>(
+pub fn compile<Pk: MiniscriptKey + PubkeyKey32>(
     pol: &Policy<Pk>,
 ) -> Result<DagTerm<(), BtcNode>, Error> {
     let two_pow_256 = pow2_types()[9].clone();

--- a/src/policy/lift.rs
+++ b/src/policy/lift.rs
@@ -1,0 +1,111 @@
+// Simplicity lifting to miniscript semantic representation
+// Written in 2020 by
+//     Sanket Kanjalkar <sanket1729@gmail.com>
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication
+// along with this software.
+// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+//
+
+//! # Lift simplicity programs into miniscript semantic policies
+//! Not all simplicity programs can be lifted to semantic langauge.
+//! Currently the policy compilation is one to one mapping
+//! between policy fragment and a simplicity program.
+
+use crate::core::bitvec_to_bytevec;
+use crate::core::term::DagTerm;
+use crate::extension::bitcoin::BtcNode;
+use crate::PubkeyKey32;
+use crate::Value;
+use bitcoin_hashes::{sha256, Hash};
+use miniscript::policy::Liftable;
+use miniscript::policy::Semantic;
+use miniscript::{DummyKey, MiniscriptKey};
+
+use crate::extension::jets::JetsNode::{EqV256, LessThanV32, SchnorrAssert, Sha256};
+
+use std::rc::Rc;
+
+/// Functional opposite of scribe. Read the scribed value
+/// by interpretting that as constant function and return
+/// a value corresponding to it.
+pub fn read_scribed_value<Witness, Ext>(dag: Rc<DagTerm<Witness, Ext>>) -> Value {
+    match dag.as_ref() {
+        DagTerm::Unit => Value::Unit,
+        DagTerm::InjL(l) => Value::sum_l(read_scribed_value(Rc::clone(l))),
+        DagTerm::InjR(r) => Value::sum_r(read_scribed_value(Rc::clone(r))),
+        DagTerm::Pair(l, r) => Value::prod(
+            read_scribed_value(Rc::clone(l)),
+            read_scribed_value(Rc::clone(r)),
+        ),
+        // Fixme: Change to errors
+        _ => unreachable!(),
+    }
+}
+
+// FIXME: Wait for 32 byte pubkeys to be added to rust-bitcoin.
+// Then, we can add implementations that depend on bitcoin::PublicKey
+impl<Witness> Liftable<DummyKey> for DagTerm<Witness, BtcNode>
+where
+    Witness: Eq,
+{
+    // Lift a simplicity program into a semantic policy
+    fn lift(&self) -> Semantic<DummyKey> {
+        match self {
+            DagTerm::Unit => Semantic::Trivial,
+            DagTerm::Comp(l, r) => {
+                // check for Key
+                match (&**l, &**r) {
+                    (DagTerm::Pair(key, w), DagTerm::Jet(SchnorrAssert)) => {
+                        let key_value = read_scribed_value(Rc::clone(&Rc::clone(&key)));
+                        let key_bytes = bitvec_to_bytevec(key_value.into_bits());
+                        let k = DummyKey::from_32_byte_pubkey(&key_bytes);
+                        match &**w {
+                            DagTerm::Witness(..) => Semantic::KeyHash(k.to_pubkeyhash()),
+                            _ => unimplemented!(),
+                        }
+                    }
+                    (DagTerm::Pair(scribed_hash, computed_hash), DagTerm::Jet(EqV256)) => {
+                        let hash_value = read_scribed_value(Rc::clone(&Rc::clone(&scribed_hash)));
+                        let hash_bytes = bitvec_to_bytevec(hash_value.into_bits());
+                        let h = sha256::Hash::from_slice(&hash_bytes).unwrap();
+                        match &**computed_hash {
+                            DagTerm::Pair(w, sha_jet) => match (&**w, &**sha_jet) {
+                                (DagTerm::Witness(..), DagTerm::Jet(Sha256)) => Semantic::Sha256(h),
+                                _ => unimplemented!(),
+                            },
+                            _ => unimplemented!(),
+                        }
+                    }
+                    (DagTerm::Pair(scibe_t, computed_t), DagTerm::Jet(LessThanV32)) => {
+                        let timelock_value = read_scribed_value(Rc::clone(&Rc::clone(&scibe_t)));
+                        let timelock_bytes = bitvec_to_bytevec(timelock_value.into_bits());
+                        let t = u32_from_be_bytes(&timelock_bytes);
+                        match &**computed_t {
+                            DagTerm::Ext(BtcNode::LockTime) => Semantic::After(t),
+                            DagTerm::Ext(BtcNode::CurrentSequence) => Semantic::After(t),
+                            _ => unimplemented!(),
+                        }
+                    }
+                    _ => unimplemented!(),
+                }
+            }
+            _ => unimplemented!(),
+        }
+    }
+}
+
+// utility function to convert 4 bytes [u8;4] to u32
+// panics if bytes.len() !=4
+fn u32_from_be_bytes(bytes: &[u8]) -> u32 {
+    assert!(bytes.len() == 4);
+    let mut ret: u32 = 0;
+    for (i, byte) in bytes.iter().enumerate() {
+        ret += (*byte as u32) * (1 << (24 - 8 * i));
+    }
+    ret
+}

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -27,3 +27,4 @@
 
 pub mod ast;
 pub mod compiler;
+pub mod lift;


### PR DESCRIPTION
Adds a policy compiler. Builds on top of #11 . 


This is PR is majorly for design and overall architecture review. There are lot of unwraps, panics that would be later transferred into sane errors. The compiler is complete but assumes custom jets that are made only for testing. The lifting code is incomplete and only works for leaf policies. We can fix that once the jets are finalized. 